### PR TITLE
Enable oauth

### DIFF
--- a/env
+++ b/env
@@ -1,0 +1,5 @@
+# add your github oauth config to this file
+# and launch the server with `sh run.sh`
+export GITHUB_CLIENT_ID=
+export GITHUB_CLIENT_SECRET=
+export OAUTH_CALLBACK_URL="http://localhost:8000/hub/oauth_callback"

--- a/jupyterhub_config.sample.py
+++ b/jupyterhub_config.sample.py
@@ -1,0 +1,22 @@
+# Configuration file for jupyterhub.
+
+import os
+
+c = get_config()
+
+# spawn with custom docker containers
+c.JupyterHub.spawner_class = 'dockerspawner.CustomDockerSpawner'
+
+# The docker instances need access to the Hub, so the default loopback port doesn't work:
+from IPython.utils.localinterfaces import public_ips
+c.JupyterHub.hub_ip = public_ips()[0]
+
+# OAuth with GitHub
+c.JupyterHub.authenticator_class = 'oauthenticator.GitHubOAuthenticator'
+c.GitHubOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
+
+# boot2docker hax
+c.Spawner.tls = True
+c.Spawner.debug = True
+c.Spawner.http_timeout = 32
+c.Spawner.container_ip = '192.168.59.103'

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+here="$(dirname $0)"
+export PYTHONPATH="$here:$here/../..:$PYTHONPATH"
+
+test -f oauthenticator.py || curl https://raw.githubusercontent.com/jupyter/oauthenticator/master/oauthenticator.py > oauthenticator.py
+# load github auth from env
+source $here/env
+
+jupyterhub $@


### PR DESCRIPTION
Anybody with a GitHub account can login. This overrides the login screen, therefore no `repo_url` can be specified for now.

Some notes to make this work:
- Create a GitHub OAuth developer application
- Fill `Client ID` and `Client Secret` into the `env` file in the root of the repository
- Run JupyterHub with `run.sh`
